### PR TITLE
Add support for TestNG

### DIFF
--- a/src/main/java/com/zyxist/chainsaw/ChainsawPlugin.java
+++ b/src/main/java/com/zyxist/chainsaw/ChainsawPlugin.java
@@ -50,6 +50,7 @@ public class ChainsawPlugin implements Plugin<Project> {
 	private static final TestEngine[] TEST_ENGINES = {
 		new JUnit4(),
 		new JUnit5(),
+		new TestNG(),
 		new NoTestEngine()
 	};
 

--- a/src/main/java/com/zyxist/chainsaw/JavaModule.java
+++ b/src/main/java/com/zyxist/chainsaw/JavaModule.java
@@ -26,6 +26,7 @@ public class JavaModule {
 	private String moduleName;
 	private boolean allowModuleNamingViolations = false;
 	private List<String> addTestModules = new ArrayList<>();
+	private List<String> exportTestPackages = new ArrayList<>();
 	private JavaModuleHacks hacks = new JavaModuleHacks();
 
 	public String getName() {
@@ -50,6 +51,14 @@ public class JavaModule {
 
 	public void setExtraTestModules(List<String> testModules) {
 		this.addTestModules = testModules;
+	}
+
+	public List<String> getExportedTestPackages() {
+		return exportTestPackages;
+	}
+
+	public void setExportedTestPackages(List<String> testPackages) {
+		this.exportTestPackages = testPackages;
 	}
 
 	public void hacks(Action<? super JavaModuleHacks> action) {

--- a/src/main/java/com/zyxist/chainsaw/tests/TestNG.java
+++ b/src/main/java/com/zyxist/chainsaw/tests/TestNG.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zyxist.chainsaw.tests;
+
+import com.zyxist.chainsaw.ChainsawPlugin;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class TestNG implements TestEngine {
+    private static final Logger LOGGER = Logging.getLogger(ChainsawPlugin.class);
+
+    private static final String TESTNG_GROUP = "org.testng";
+    private static final String TESTNG_ARTIFACT = "testng";
+
+    private static final String TESTNG_MODULE_NAME = "testng";
+
+    @Override
+    public boolean accepts(Project project) {
+        return TestEngine.checkTestDependencies(project, dep -> dep.getGroup().equals(TESTNG_GROUP) && dep.getName().equals(TESTNG_ARTIFACT));
+    }
+
+    @Override
+    public List<String> getTestEngineModules() {
+        return Arrays.asList(TESTNG_MODULE_NAME);
+    }
+}

--- a/src/main/java/com/zyxist/chainsaw/tests/TestTaskConfigurator.java
+++ b/src/main/java/com/zyxist/chainsaw/tests/TestTaskConfigurator.java
@@ -19,6 +19,7 @@ import com.zyxist.chainsaw.JavaModule;
 import com.zyxist.chainsaw.TaskConfigurator;
 import com.zyxist.chainsaw.algorithms.ModulePatcher;
 import com.zyxist.chainsaw.jigsaw.JigsawCLI;
+import com.zyxist.chainsaw.jigsaw.cli.ExportItem;
 import com.zyxist.chainsaw.jigsaw.cli.PatchItem;
 import com.zyxist.chainsaw.jigsaw.cli.ReadItem;
 import org.gradle.api.Action;
@@ -62,6 +63,10 @@ public class TestTaskConfigurator implements TaskConfigurator<Test> {
 				.read(new ReadItem(moduleConfig.getName())
 					.toAll(testEngine.getTestEngineModules())
 					.toAll(moduleConfig.getExtraTestModules()));
+			moduleConfig.getExportedTestPackages().forEach(exportTestPackage -> cli.exportList()
+				.export(new ExportItem(moduleConfig.getName(), exportTestPackage)
+					.toAll(testEngine.getTestEngineModules())));
+
 			moduleConfig.getHacks().applyHacks(cli);
 			patcher
 				.patchFrom(project, PATCH_CONFIGURATION_NAME)

--- a/src/test/groovy/com/zyxist/chainsaw/builder/Dependencies.java
+++ b/src/test/groovy/com/zyxist/chainsaw/builder/Dependencies.java
@@ -20,6 +20,7 @@ public class Dependencies {
 	public static final String JUNIT5_PLUGIN_DEPENDENCY = "org.junit.platform:junit-platform-gradle-plugin:1.0.0";
 	public static final String JUNIT5_API_DEPENDENCY = "org.junit.jupiter:junit-jupiter-api:5.0.0";
 	public static final String JUNIT5_ENGINE_DEPENDENCY = "org.junit.jupiter:junit-jupiter-engine:5.0.0";
+	public static final String TESTNG_DEPENDENCY = "org.testng:testng:6.14.2";
 	public static final String MOCKITO_DEPENDENCY = "org.mockito:mockito-core:2.11.0";
 	public static final String GUAVA_DEPENDENCY = "com.google.guava:guava:23.2-jre";
 	public static final String GUICE_DEPENDENCY = "com.google.inject:guice:4.2.0";

--- a/src/test/groovy/com/zyxist/chainsaw/builder/JigsawProjectBuilder.java
+++ b/src/test/groovy/com/zyxist/chainsaw/builder/JigsawProjectBuilder.java
@@ -49,6 +49,7 @@ public class JigsawProjectBuilder {
 	private final List<String> exportedPackages = new ArrayList<>();
 
 	private final List<String> extraTestModules = new ArrayList<>();
+	private final List<String> exportedTestPackages = new ArrayList<>();
 	private final List<String> openConfig = new ArrayList<>();
 	private final List<String> patchConfig = new ArrayList<>();
 
@@ -147,6 +148,11 @@ public class JigsawProjectBuilder {
 
 	public JigsawProjectBuilder extraTestModule(String moduleName) {
 		this.extraTestModules.add(moduleName);
+		return this;
+	}
+
+	public JigsawProjectBuilder exportedTestPackage(String pkg) {
+		this.exportedTestPackages.add(pkg);
 		return this;
 	}
 
@@ -314,8 +320,11 @@ public class JigsawProjectBuilder {
 	}
 
 	private void generateTestConfig(StringBuilder build) {
-		if (!testJvmArgs.isEmpty()) {
+		if (!testJvmArgs.isEmpty() || !testCompileDependencies.isEmpty()) {
 			build.append("test {\n");
+			if (testCompileDependencies.contains(Dependencies.TESTNG_DEPENDENCY)) {
+				build.append("  useTestNG()");
+			}
 			for (String arg: testJvmArgs) {
 				build.append("    jvmArgs '" + arg + "'\n");
 			}
@@ -332,6 +341,9 @@ public class JigsawProjectBuilder {
 		}
 		if (!extraTestModules.isEmpty()) {
 			build.append("javaModule.extraTestModules = ['" + String.join("', '", extraTestModules) + "']\n");
+		}
+		if (!exportedTestPackages.isEmpty()) {
+			build.append("javaModule.exportedTestPackages = ['" + String.join("', '", exportedTestPackages) + "']\n");
 		}
 		if (!patchConfig.isEmpty() || ! openConfig.isEmpty()) {
 			build.append("javaModule.hacks {\n");

--- a/src/test/groovy/com/zyxist/chainsaw/builder/factory/TestNGExportedTestPackageTestFactory.groovy
+++ b/src/test/groovy/com/zyxist/chainsaw/builder/factory/TestNGExportedTestPackageTestFactory.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zyxist.chainsaw.builder.factory
+
+import com.zyxist.chainsaw.builder.JavaCodeFactory
+import com.zyxist.chainsaw.builder.JigsawProjectBuilder
+
+class TestNGExportedTestPackageTestFactory implements JavaCodeFactory {
+	boolean mocks;
+
+	static def exportedTestPackageTest() {
+		def factory = new TestNGExportedTestPackageTestFactory()
+		factory.mocks = false
+		return factory
+	}
+
+	static def exportedTestPackageTestWithMocks() {
+		def factory = new TestNGExportedTestPackageTestFactory()
+		factory.mocks = true
+		return factory
+	}
+
+	@Override
+	String getFilename(JigsawProjectBuilder builder) {
+		return builder.getPackageName().replace(".", "/") + "/test/AClassTest.java"
+	}
+
+	@Override
+	String generateCode(JigsawProjectBuilder builder) {
+		def mockitoImport = ""
+		def mockitoUsage = ""
+		if (mocks) {
+			mockitoImport = "import static org.mockito.Mockito.mock;"
+			mockitoUsage = "Object obj = mock(Object.class);"
+		}
+		return """
+package ${builder.getPackageName()}.test;
+
+import ${builder.getPackageName()}.AClass;
+${mockitoImport}
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertTrue;
+
+public class AClassTest {
+  @Test
+  public void isAnInstanceOfAClass() {
+      ${mockitoUsage}
+      assertTrue(new AImplementation() instanceof AClass);
+  }
+  
+  static class AImplementation extends AClass {
+    @Override
+    public void aMethod(String aString) {
+        // Do nothing
+    }
+  }
+}
+"""
+	}
+}

--- a/src/test/groovy/com/zyxist/chainsaw/builder/factory/TestNGSampleTestFactory.groovy
+++ b/src/test/groovy/com/zyxist/chainsaw/builder/factory/TestNGSampleTestFactory.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zyxist.chainsaw.builder.factory
+
+import com.zyxist.chainsaw.builder.JavaCodeFactory
+import com.zyxist.chainsaw.builder.JigsawProjectBuilder
+
+class TestNGSampleTestFactory implements JavaCodeFactory {
+	boolean mocks;
+
+	static def testngTest() {
+		def factory = new TestNGSampleTestFactory()
+		factory.mocks = false
+		return factory
+	}
+
+	static def testngTestWithMocks() {
+		def factory = new TestNGSampleTestFactory()
+		factory.mocks = true
+		return factory
+	}
+
+	@Override
+	String getFilename(JigsawProjectBuilder builder) {
+		return builder.getPackageName().replace(".", "/") + "/AClassTest.java"
+	}
+
+	@Override
+	String generateCode(JigsawProjectBuilder builder) {
+		def mockitoImport = ""
+		def mockitoUsage = ""
+		if (mocks) {
+			mockitoImport = "import static org.mockito.Mockito.mock;"
+			mockitoUsage = "Object obj = mock(Object.class);"
+		}
+		return """
+package ${builder.getPackageName()};
+
+${mockitoImport}
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertTrue;
+
+public class AClassTest {
+  @Test
+  public void isAnInstanceOfAClass() {
+      ${mockitoUsage}
+      assertTrue(new AImplementation() instanceof AClass);
+  }
+  
+  static class AImplementation extends AClass {
+    @Override
+    public void aMethod(String aString) {
+        // Do nothing
+    }
+  }
+}
+"""
+	}
+}

--- a/src/test/groovy/com/zyxist/chainsaw/integration/TestNGTestSpec.groovy
+++ b/src/test/groovy/com/zyxist/chainsaw/integration/TestNGTestSpec.groovy
@@ -24,6 +24,7 @@ import spock.lang.IgnoreIf
 import spock.lang.Specification
 
 import static com.zyxist.chainsaw.builder.factory.TestNGSampleTestFactory.testngTestWithMocks
+import static com.zyxist.chainsaw.builder.factory.TestNGExportedTestPackageTestFactory.exportedTestPackageTestWithMocks
 import static com.zyxist.chainsaw.builder.factory.RegularJavaClassFactory.regularJavaClass
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
@@ -71,6 +72,28 @@ class TestNGTestSpec extends Specification {
 		given:
 		project
 			.gradleJavaPlugin("application")
+			.createGradleBuild()
+			.createModuleDescriptor()
+
+		when:
+		def result = GradleRunner.create()
+			.withProjectDir(tmpDir.root)
+			.withDebug(true)
+			.forwardOutput()
+			.withArguments("check")
+			.withPluginClasspath().build()
+
+		then:
+		result.task(":test").outcome == SUCCESS
+	}
+
+	@IgnoreIf({NOT_JAVA_9})
+	def "run TestNG with explicitly exported test packages"() {
+		given:
+		project
+			.gradleJavaPlugin("application")
+			.createJavaTestFile(exportedTestPackageTestWithMocks())
+			.exportedTestPackage("com.example.test")
 			.createGradleBuild()
 			.createModuleDescriptor()
 

--- a/src/test/groovy/com/zyxist/chainsaw/integration/TestNGTestSpec.groovy
+++ b/src/test/groovy/com/zyxist/chainsaw/integration/TestNGTestSpec.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zyxist.chainsaw.integration
+
+import com.zyxist.chainsaw.builder.Dependencies
+import com.zyxist.chainsaw.builder.JigsawProjectBuilder
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+
+import static com.zyxist.chainsaw.builder.factory.TestNGSampleTestFactory.testngTestWithMocks
+import static com.zyxist.chainsaw.builder.factory.RegularJavaClassFactory.regularJavaClass
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class TestNGTestSpec extends Specification {
+	static final NOT_JAVA_9 = !System.getProperty("java.version").startsWith("9")
+	@Rule
+	final TemporaryFolder tmpDir = new TemporaryFolder()
+
+	JigsawProjectBuilder project
+
+	def setup() {
+		project = new JigsawProjectBuilder(tmpDir)
+		project.moduleName("com.example")
+			.packageName("com.example")
+			.exportedPackage("com.example")
+			.testCompileDependency(Dependencies.TESTNG_DEPENDENCY)
+			.testCompileDependency(Dependencies.MOCKITO_DEPENDENCY)
+			.extraTestModule(Dependencies.MOCKITO_MODULE)
+			.createJavaFile(regularJavaClass("AClass"))
+			.createJavaTestFile(testngTestWithMocks())
+	}
+
+	@IgnoreIf({NOT_JAVA_9})
+	def "run TestNG tests with Mockito - java plugin way"() {
+		given:
+		project
+			.gradleJavaPlugin("java")
+			.createGradleBuild()
+			.createModuleDescriptor()
+
+		when:
+		def result = GradleRunner.create()
+			.withProjectDir(project.root)
+			.withDebug(true)
+			.forwardOutput()
+			.withArguments("check")
+			.withPluginClasspath().build()
+
+		then:
+		result.task(":test").outcome == SUCCESS
+	}
+
+	@IgnoreIf({NOT_JAVA_9})
+	def "run TestNG tests with Mockito - new way"() {
+		given:
+		project
+			.gradleJavaPlugin("application")
+			.createGradleBuild()
+			.createModuleDescriptor()
+
+		when:
+		def result = GradleRunner.create()
+			.withProjectDir(tmpDir.root)
+			.withDebug(true)
+			.forwardOutput()
+			.withArguments("check")
+			.withPluginClasspath().build()
+
+		then:
+		result.task(":test").outcome == SUCCESS
+	}
+}


### PR DESCRIPTION
This is a rudimentary attempt to add TestNG support to the plugin. Most of this stuff has been straightup copied and adjusted from existing Junit support.
Additionally, test packages may now be exported to all test engine modules. (See `JavaModule` change). This is necessary for TestNG to run due to how classes are initialized.

Unfortunately I do not have as much time to dig into the source of this plugin as I'd like, but I hope that this PR (even if this does not get merged) serves as a basis for TestNG support.